### PR TITLE
Add pity to card upgrades

### DIFF
--- a/src/entities/card.ts
+++ b/src/entities/card.ts
@@ -61,6 +61,9 @@ export class Card {
 	@Column('datetime', { name: 'job_mindblocked_until', nullable: true })
 	jobMindblockedUntil!: Date | null;
 
+	@Column('int', { name: 'pity', default: 0, nullable: false })
+	pity!: number;
+
 	@BeforeInsert()
 	@BeforeUpdate()
 	calculateBurnValue() {


### PR DESCRIPTION
Implemented this as a way to propose its workings, I think the results are solid
- Added Pity column to the Card entity
- Pity gets increased by 1 every time a card **_downgrades_**
  - Pity increases the chance to upgrade a card by 7%, capped at 80% maximum
  - Pity decreases the chance to downgrade a card by 7%, capped at 30% minimum
 
basically applying an "what doesn't kill you makes you stronger" philosophy to limit extreme sequences of bad luck, without tampering with regular fail chains

tested through simulating upgrades from **badly damaged** to **mint**, the system has the following effects:

| Upgrades | No Pity | Pity |
|----------|---------|------|
| Mean     | 1750    | 1622 |
| Median   | 1350    | 1350 |
| Std Dev  | 1092    | 833  |

Aka it mainly aims to lower the standard deviation, as most of it is built up in the upper end due to Mean - Std Dev going far below the minimum cost to upgrade
Below are 2 graphs for comparison across the board

No Pity (current)
![firefox_cHGPEGhpcy](https://github.com/user-attachments/assets/c4e5215c-f772-433c-ab7b-d493b0f45617)

Pity (implemented in this PR)
![firefox_x68rocqryS](https://github.com/user-attachments/assets/eaefd00f-8d53-4083-8c02-cba9e1e1a932)
