### PR TITLE
Support 5-length IDs

### DIFF
--- a/src/commands/drop.ts
+++ b/src/commands/drop.ts
@@ -13,6 +13,7 @@ import { getNextCardId } from '../services/getNextCardId.js';
 import { GuildSettings } from '../entities/guildSettings.js';
 import { EventLogService } from '../services/eventLogService.js';
 import { unlink } from 'fs/promises';
+import { stringId } from '../lib/utils.js';
 
 @ApplyOptions<Command.Options>({
 	description: 'Drops 3 cards'
@@ -203,16 +204,4 @@ export class DropCommand extends Command {
 			console.error('Failed to post settings hint', e);
 		}
 	}
-}
-
-function stringId(id: number) {
-	let stringId = '';
-	const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-
-	for (let i = 0; i < 4; i++) {
-		stringId += chars[id % chars.length];
-		id = Math.floor(id / chars.length);
-	}
-
-	return stringId.split('').reverse().join('');
 }

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -51,7 +51,7 @@ export class JobsCommand extends Subcommand {
 						.setName('assign')
 						.setDescription('Assign card to slot')
 						.addStringOption((arg) =>
-							arg.setName('card').setDescription('Card to assign').setRequired(true).setMaxLength(4).setMinLength(4)
+							arg.setName('card').setDescription('Card to assign').setRequired(true).setMaxLength(5).setMinLength(4)
 						)
 						.addStringOption((arg) =>
 							arg

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -12,6 +12,7 @@ import { DiscordUser } from '../entities/discordUser.js';
 import { getNextCardId } from '../services/getNextCardId.js';
 import { EventLogService } from '../services/eventLogService.js';
 import { unlink } from 'fs/promises';
+import { stringId } from '../lib/utils.js';
 
 export class UseCommand extends Command {
 	registerApplicationCommands(registry: ApplicationCommandRegistry) {
@@ -191,16 +192,4 @@ export class UseCommand extends Command {
             } catch(e) {}
 		}, 1000 * 60);
 	}
-}
-
-function stringId(id: number) {
-	let stringId = '';
-	const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-
-	for (let i = 0; i < 4; i++) {
-		stringId += chars[id % chars.length];
-		id = Math.floor(id / chars.length);
-	}
-
-	return stringId.split('').reverse().join('');
 }

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -21,13 +21,6 @@ export class ViewCommand extends Command {
   public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
     const id = interaction.options.getString('card')!
 
-    if(id.length != 4) {
-      await interaction.reply({
-        content: 'Invalid card code',
-        ephemeral: true
-      })
-      return;
-    }
 
     const card = await db
         .getRepository(Card)

--- a/src/entities/card.ts
+++ b/src/entities/card.ts
@@ -5,7 +5,7 @@ import { CardCondition } from './cardCondition.js';
 
 @Entity('card')
 export class Card {
-	@PrimaryColumn('char', { length: 4 })
+	@PrimaryColumn('char', { length: 5 })
 	id!: string;
 
 	@ManyToOne(() => Mapper, { eager: false, nullable: false })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -51,3 +51,19 @@ function getGuildInfo(guild: Guild | null, channel: | Channel | null) {
 
 	return text
 }
+
+export function stringId(id: number) {
+	let stringId = '';
+	const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+	const is5Digit = id >= 36 ** 4;
+	const length = is5Digit ? 5 : 4;
+	if (is5Digit) id -= 36 ** 4;
+
+	for (let i = 0; i < length; i++) {
+		stringId += chars[id % chars.length];
+		id = Math.floor(id / chars.length);
+	}
+
+	return stringId.split('').reverse().join('');
+}


### PR DESCRIPTION
I setup the bot locally and tested every command interacting with cards. They should all support 5-length IDs with these changes now

New cards are generated with 5-length IDs starting at `aaaaa`

Requires changing `card.id` to `char(5)` in the DB. My migration is shown below so just run each line one-by-one to first remove the constraints (ignoring them seemed to not work) and then add them back. Probably have to replace the two foreign keys with whatever names are generated for your DBs. I didn't test with synchronize in typeorm, maybe that also works

```sql
-- drop foreign key constraints using card.id
ALTER TABLE hifumin.trade_offer DROP FOREIGN KEY FK_d2ae2895fd7b7bc3bdb59627b47;
ALTER TABLE hifumin.job_assignment DROP FOREIGN KEY FK_090f9cdadc3494903c11f8bae5a;

ALTER TABLE hifumin.card MODIFY COLUMN id char(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;

-- add back the removed foreign key constraints
ALTER TABLE hifumin.trade_offer ADD CONSTRAINT FK_d2ae2895fd7b7bc3bdb59627b47 FOREIGN KEY (card_id) REFERENCES hifumin.card(id);
ALTER TABLE hifumin.job_assignment ADD CONSTRAINT FK_090f9cdadc3494903c11f8bae5a FOREIGN KEY (card_id) REFERENCES hifumin.card(id);
```